### PR TITLE
Add RemNote flashcard rate tracker plugin skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# RemNote Flashcard Rate Tracker
+
+This project contains a sample RemNote plugin that gamifies global queue reviews
+by tracking your flashcard speed.
+
+## Features
+- Displays a sidebar widget with:
+  - Session duration
+  - Cards answered correctly and incorrectly
+  - Current cards-per-minute rate
+  - Best rate across all sessions
+- Stores the high score in plugin storage.
+- Plays a celebratory sound and toast when you beat your previous best rate.
+
+## Development
+1. Install dependencies
+   ```bash
+   npm install
+   ```
+2. Build the plugin
+   ```bash
+   npm run build
+   ```
+3. Load the `dist` folder as a plugin in RemNote.
+
+## Usage
+- Run the command **Start Flashcard Session** before you begin reviewing.
+- Review cards as usual. Statistics will update in the sidebar.
+- Run **End Flashcard Session** when you're done to record your top speed.

--- a/Test
+++ b/Test
@@ -1,1 +1,0 @@
-print("hello")

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,256 @@
+{
+  "name": "remnote-flashcard-rate-tracker",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "remnote-flashcard-rate-tracker",
+      "version": "0.1.0",
+      "dependencies": {
+        "@remnote/plugin-sdk": "^0.0.46",
+        "react": "^17.0.2"
+      },
+      "devDependencies": {
+        "@types/react": "^17.0.67",
+        "typescript": "^5.6.3"
+      }
+    },
+    "node_modules/@remnote/plugin-sdk": {
+      "version": "0.0.46",
+      "resolved": "https://registry.npmjs.org/@remnote/plugin-sdk/-/plugin-sdk-0.0.46.tgz",
+      "integrity": "sha512-LrHxLeIDFfrpCFgN2+0n/uhGpZU2gQhCBUD2dDCLBR3AsyV0w95KR6flx4woYitJbHCIlVod8ByqCheDua8HsQ==",
+      "license": "ISC",
+      "dependencies": {
+        "ansi-colors": "^4.1.3",
+        "enquirer": "^2.3.6",
+        "mitt": "^3.0.0",
+        "nanoid": "^3.3.1",
+        "os": "^0.1.2",
+        "type-fest": "^2.12.1",
+        "underscore": "^1.13.2",
+        "zod": "^3.22.2"
+      },
+      "bin": {
+        "remnote-plugin": "scripts/index.js"
+      },
+      "peerDependencies": {
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "17.0.88",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.88.tgz",
+      "integrity": "sha512-HEOvpzcFWkEcHq4EsTChnpimRc3Lz1/qzYRDFtobFp4obVa6QVjCDMjWmkgxgaTYttNvyjnldY8MUflGp5YiUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "^0.16",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/scheduler": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
+      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/enquirer": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.1",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/os": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/os/-/os-0.1.2.tgz",
+      "integrity": "sha512-ZoXJkvAnljwvc56MbvhtKVWmSkzV712k42Is2mA0+0KTSRakq5XXuXpjZjgAt9ctzl51ojhQWakQQpmOvXWfjQ==",
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "scheduler": "^0.20.2"
+      },
+      "peerDependencies": {
+        "react": "17.0.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/underscore": {
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
+      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+      "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "remnote-flashcard-rate-tracker",
+  "version": "0.1.0",
+  "description": "RemNote plugin that gamifies flashcard sessions by tracking rate and high scores",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "test": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@remnote/plugin-sdk": "^0.0.46",
+    "react": "^17.0.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.3",
+    "@types/react": "^17.0.67"
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,37 @@
+import {
+  declareIndexPlugin,
+  WidgetLocation,
+  AppEvents,
+  ReactRNPlugin,
+} from '@remnote/plugin-sdk';
+import { SessionTracker } from './tracker';
+
+async function onActivate(plugin: ReactRNPlugin) {
+  const tracker = new SessionTracker(plugin);
+  await tracker.init();
+  (window as any).tracker = tracker;
+
+  await plugin.app.registerCommand({
+    id: 'start-flashcard-session',
+    name: 'Start Flashcard Session',
+    action: () => tracker.startSession(),
+  });
+
+  await plugin.app.registerCommand({
+    id: 'end-flashcard-session',
+    name: 'End Flashcard Session',
+    action: () => tracker.endSession(),
+  });
+
+  plugin.event.addListener(AppEvents.QueueCompleteCard, 'tracker', (data: any) => {
+    tracker.recordAnswer(data.correct ?? true);
+  });
+
+  await plugin.app.registerWidget('session-stats', WidgetLocation.RightSidebar, {
+    dimensions: { width: 300, height: 180 },
+  });
+}
+
+async function onDeactivate(plugin: ReactRNPlugin) {}
+
+declareIndexPlugin(onActivate, onDeactivate);

--- a/src/session-stats.tsx
+++ b/src/session-stats.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from 'react';
+import { renderWidget } from '@remnote/plugin-sdk';
+import { SessionTracker, SessionSnapshot } from './tracker';
+
+declare global {
+  interface Window {
+    tracker: SessionTracker;
+  }
+}
+
+const StatsWidget: React.FC = () => {
+  const tracker = window.tracker;
+  const [stats, setStats] = useState<SessionSnapshot>(tracker.snapshot());
+
+  useEffect(() => {
+    const listener = () => setStats(tracker.snapshot());
+    tracker.onUpdate(listener);
+    return () => tracker.offUpdate(listener);
+  }, [tracker]);
+
+  return (
+    <div style={{ padding: 8 }}>
+      <h3>Session Stats</h3>
+      <div>Duration: {stats.duration}s</div>
+      <div>Correct: {stats.correct}</div>
+      <div>Incorrect: {stats.incorrect}</div>
+      <div>Rate: {stats.rate.toFixed(2)} cards/min</div>
+      <div>Top Rate: {stats.topRate.toFixed(2)} cards/min</div>
+    </div>
+  );
+};
+
+renderWidget(StatsWidget as any);

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -1,0 +1,84 @@
+import type { ReactRNPlugin } from '@remnote/plugin-sdk';
+
+export interface SessionSnapshot {
+  duration: number; // seconds
+  correct: number;
+  incorrect: number;
+  rate: number; // cards per minute
+  topRate: number;
+}
+
+export class SessionTracker {
+  private startTime: number | undefined;
+  private correct = 0;
+  private incorrect = 0;
+  private topRate = 0;
+  private listeners: (() => void)[] = [];
+
+  constructor(private plugin: ReactRNPlugin) {}
+
+  async init() {
+    this.topRate = (await this.plugin.storage.getSynced<number>('topRate')) || 0;
+  }
+
+  startSession() {
+    this.startTime = Date.now();
+    this.correct = 0;
+    this.incorrect = 0;
+    this.notify();
+  }
+
+  recordAnswer(correct: boolean) {
+    if (!this.startTime) {
+      this.startSession();
+    }
+    correct ? this.correct++ : this.incorrect++;
+    this.notify();
+  }
+
+  async endSession() {
+    const rate = this.snapshot().rate;
+    if (rate > this.topRate) {
+      this.topRate = rate;
+      await this.plugin.storage.setSynced('topRate', this.topRate);
+      // celebratory toast and sound
+      await this.plugin.app.toast(`New high score: ${rate.toFixed(2)} cards/min!`);
+      try {
+        const audio = new Audio('https://actions.google.com/sounds/v1/cartoon/clang_and_wobble.ogg');
+        audio.play();
+      } catch {
+        // ignore audio errors
+      }
+    }
+    this.startTime = undefined;
+    this.correct = 0;
+    this.incorrect = 0;
+    this.notify();
+  }
+
+  snapshot(): SessionSnapshot {
+    const duration = this.startTime ? Math.floor((Date.now() - this.startTime) / 1000) : 0;
+    const total = this.correct + this.incorrect;
+    const minutes = duration / 60;
+    const rate = minutes > 0 ? total / minutes : 0;
+    return {
+      duration,
+      correct: this.correct,
+      incorrect: this.incorrect,
+      rate,
+      topRate: this.topRate,
+    };
+  }
+
+  onUpdate(f: () => void) {
+    this.listeners.push(f);
+  }
+  offUpdate(f: () => void) {
+    this.listeners = this.listeners.filter((l) => l !== f);
+  }
+  private notify() {
+    for (const f of this.listeners) {
+      f();
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "lib": ["es2019", "dom"],
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "jsx": "react",
+    "strict": false
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- Scaffold RemNote plugin that tracks flashcard sessions and registers sidebar stats widget.
- Implement session tracker with rate calculation, persistent high score, and celebratory toast and audio.
- Provide development README and TypeScript build configuration.

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2711298c8832f9f6b90fc853422f6